### PR TITLE
Suppression dépendance à la taglib spring dans les JSP

### DIFF
--- a/src/main/webapp/WEB-INF/layouts/mobile/about.jsp
+++ b/src/main/webapp/WEB-INF/layouts/mobile/about.jsp
@@ -1,5 +1,5 @@
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <!DOCTYPE html>
 <html lang="en"
 	xmlns="http://www.w3.org/1999/xhtml">
@@ -10,18 +10,18 @@
 		<div id="topbar-about" class="navbar navbar-fixed-top topbar" >
 			<div class="navbar-inner">	
 				<div class="container">
-					<a class="brand" href="/tatami/"><img src="/assets/img/ippon-logo.png"></img><spring:message
-                    code="tatami.title"/></a>
+					<a class="brand" href="/tatami/"><img src="/assets/img/ippon-logo.png"></img><fmt:message
+                    key="tatami.title"/></a>
 					<div class="nav-collapse noMargin noPadding">
 						<ul class="nav">
-							<li><a href="/tatami/"><i class="icon-home icon-white"></i><spring:message
-                    code="tatami.home"/></a></li>
-							<li class="active"><a href="#"><i class="icon-info-sign icon-white"></i>&nbsp;<spring:message
-                    code="tatami.about"/></a></li>
+							<li><a href="/tatami/"><i class="icon-home icon-white"></i><fmt:message
+                    key="tatami.home"/></a></li>
+							<li class="active"><a href="#"><i class="icon-info-sign icon-white"></i>&nbsp;<fmt:message
+                    key="tatami.about"/></a></li>
 						</ul>
 						<ul class="nav pull-right">
-							<li><a href="/tatami/logout"><i class="icon-user icon-white"></i>&nbsp;<spring:message
-                    code="tatami.logout"/></a></li>
+							<li><a href="/tatami/logout"><i class="icon-user icon-white"></i>&nbsp;<fmt:message
+                    key="tatami.logout"/></a></li>
 						</ul>
 					</div>
 				</div>
@@ -30,26 +30,26 @@
 
     <div id="aboutPage" class="container row-fluid">
 	    <div class="span12 noMargin">
-	        <h1><spring:message code="tatami.presentation"/></h1>
+	        <h1><fmt:message key="tatami.presentation"/></h1>
 	
-	        <p><spring:message code="tatami.presentation.text"/></p>
+	        <p><fmt:message key="tatami.presentation.text"/></p>
 	
 	        <p>
-	            <spring:message code="tatami.presentation.moreinfo"/><a href="https://github.com/ippontech/tatami">https://github.com/ippontech/tatami</a>
+	            <fmt:message key="tatami.presentation.moreinfo"/><a href="https://github.com/ippontech/tatami">https://github.com/ippontech/tatami</a>
 	        </p>
 	    </div>
 	    <div class="span12 noMargin">
-	        <h1><spring:message code="tatami.license"/></h1>
+	        <h1><fmt:message key="tatami.license"/></h1>
 	
-	        <p><spring:message code="tatami.copyright"/> <a href="http://www.ippon.fr"><spring:message
-	                code="tatami.ippon.technologies"/></a></p>
+	        <p><fmt:message key="tatami.copyright"/> <a href="http://www.ippon.fr"><fmt:message
+	                key="tatami.ippon.technologies"/></a></p>
 	
-	        <p><spring:message code="tatami.license.text"/></p>
+	        <p><fmt:message key="tatami.license.text"/></p>
 	
 	        <p><a href="http://www.apache.org/licenses/LICENSE-2.0"></a><a
 	                href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a></p>
 	
-	        <p><spring:message code="tatami.cg"/></p>
+	        <p><fmt:message key="tatami.cg"/></p>
 	    </div>
     </div>
 

--- a/src/main/webapp/WEB-INF/layouts/mobile/home.jsp
+++ b/src/main/webapp/WEB-INF/layouts/mobile/home.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
 <!DOCTYPE html>
 <html lang="en"
@@ -10,18 +10,18 @@
 		<div id="topbar-home" class="navbar navbar-fixed-top topbar" >
 			<div class="navbar-inner">
 				<div class="container">
-					<a class="brand" href="#"><img src="/assets/img/ippon-logo.png"></img><spring:message
-                    code="tatami.title"/></a>
+					<a class="brand" href="#"><img src="/assets/img/ippon-logo.png"></img><fmt:message
+                    key="tatami.title"/></a>
 					<div class="nav-collapse">
 						<ul class="nav">
-							<li class="active"><a href="/tatami/"><i class="icon-home icon-white"></i>&nbsp;<spring:message
-                            code="tatami.home"/></a></li>
-	                        <li><a href="/tatami/about"><i class="icon-info-sign icon-white"></i>&nbsp;<spring:message
-                            code="tatami.about"/></a></li>
+							<li class="active"><a href="/tatami/"><i class="icon-home icon-white"></i>&nbsp;<fmt:message
+                            key="tatami.home"/></a></li>
+	                        <li><a href="/tatami/about"><i class="icon-info-sign icon-white"></i>&nbsp;<fmt:message
+                            key="tatami.about"/></a></li>
 						</ul>
 						<ul class="nav pull-right">
-							<li><a href="/tatami/logout"><i class="icon-user icon-white"></i>&nbsp;<spring:message
-                            code="tatami.logout"/></a></li>
+							<li><a href="/tatami/logout"><i class="icon-user icon-white"></i>&nbsp;<fmt:message
+                            key="tatami.logout"/></a></li>
 						</ul>
 					</div><!--/.nav-collapse -->
 				</div>
@@ -32,35 +32,35 @@
            <ul class="nav nav-tabs">
            		<li class="dropdown">
             		<a id="defaultTab" href="#homePanel" data-toggle="tab">
-            			<img src="/assets/img/glyphicons_322_twitter.png"></img>&nbsp;<spring:message code="tatami.new.tweet"/></a>
+            			<img src="/assets/img/glyphicons_322_twitter.png"></img>&nbsp;<fmt:message key="tatami.new.tweet"/></a>
 				</li>
 				<li class="dropdown">
             		<a id="timelineTab" href="#timelinePanel" data-toggle="tab">
-            			<img src="/assets/img/glyphicons_309_comments.png"></img>&nbsp;<spring:message code="tatami.tweets"/></a>
+            			<img src="/assets/img/glyphicons_309_comments.png"></img>&nbsp;<fmt:message key="tatami.tweets"/></a>
 				</li>
 				<li class="dropdown">
 					<a href="#" class="dropdown-toggle" data-toggle="dropdown">
-						<img src="/assets/img/glyphicons_153_more_windows.png"></img>&nbsp;<spring:message code="tatami.more"/><b class="caret"></b></a>
+						<img src="/assets/img/glyphicons_153_more_windows.png"></img>&nbsp;<fmt:message key="tatami.more"/><b class="caret"></b></a>
 		            <ul class="dropdown-menu">
 		            	<li>
 		            		<a id="profileTab" href="#profilePanel"  data-toggle="tab">
-		            			<i class="icon-edit"></i>&nbsp;<spring:message code="tatami.update.profile.mobile" /></a>
+		            			<i class="icon-edit"></i>&nbsp;<fmt:message key="tatami.update.profile.mobile" /></a>
 		            	</li>
 		            	<li>
 		            		<a id="favoriteTab" href="#favlinePanel"  data-toggle="tab">
-		            			<i class="icon-star"></i>&nbsp;<spring:message code="tatami.favorites.mobile" /></a>
+		            			<i class="icon-star"></i>&nbsp;<fmt:message key="tatami.favorites.mobile" /></a>
 		            	</li>
 		            	<li>
 		            		<a id="userlineTab" href="#userlinePanel" data-toggle="tab">
-		            			<img src="/assets/img/glyphicons_024_parents.png"></img>&nbsp;<spring:message code="tatami.userline.mobile" /></a>
+		            			<img src="/assets/img/glyphicons_024_parents.png"></img>&nbsp;<fmt:message key="tatami.userline.mobile" /></a>
 		            	</li>
 						<li>
 		            		<a id="taglineTab" href="#taglinePanel" data-toggle="tab">
-		            			<i class="icon-tags"></i>&nbsp;<spring:message code="tatami.tagline.mobile" /></a>
+		            			<i class="icon-tags"></i>&nbsp;<fmt:message key="tatami.tagline.mobile" /></a>
 		            	</li>
 		            	<li>
 		            		<a id="followTab" href="#followPanel"  data-toggle="tab">
-		            			<i class="icon-random"></i>&nbsp;<spring:message code="tatami.user.suggestions.mobile" /></a>
+		            			<i class="icon-random"></i>&nbsp;<fmt:message key="tatami.user.suggestions.mobile" /></a>
 		            	</li>
 		            </ul>
 				</li>
@@ -108,7 +108,7 @@
 							</tr>
 							<tr>
 								<td>
-									<button id="tweetButton" type="button" class="btn btn-primary"><spring:message code="tatami.user.tweet" /></button>
+									<button id="tweetButton" type="button" class="btn btn-primary"><fmt:message key="tatami.user.tweet" /></button>
 								</td>
 							</tr>
 						</table>			

--- a/src/main/webapp/WEB-INF/layouts/mobile/includes/footer.jsp
+++ b/src/main/webapp/WEB-INF/layouts/mobile/includes/footer.jsp
@@ -1,13 +1,13 @@
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags"%>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 <!-- FOOTER Templates -->
 <footer id="center-footer">
 	<div id="footerText">
-        <spring:message code="tatami.copyright"/>
-        <a href="http://www.ippon.fr"><spring:message code="tatami.ippon.technologies"/></a> |
-        <a href="https://github.com/ippontech/tatami"><spring:message code="tatami.github.fork"/></a> |
-        <a href="http://blog.ippon.fr"><spring:message code="tatami.ippon.blog"/></a> |
-        <a href="https://twitter.com/#!/ippontech"><spring:message code="tatami.ippon.twitter.follow"/></a>
+        <fmt:message key="tatami.copyright"/>
+        <a href="http://www.ippon.fr"><fmt:message key="tatami.ippon.technologies"/></a> |
+        <a href="https://github.com/ippontech/tatami"><fmt:message key="tatami.github.fork"/></a> |
+        <a href="http://blog.ippon.fr"><fmt:message key="tatami.ippon.blog"/></a> |
+        <a href="https://twitter.com/#!/ippontech"><fmt:message key="tatami.ippon.twitter.follow"/></a>
 		<br />
 	</div>
 	

--- a/src/main/webapp/WEB-INF/layouts/mobile/includes/header.jsp
+++ b/src/main/webapp/WEB-INF/layouts/mobile/includes/header.jsp
@@ -1,8 +1,8 @@
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 <head>
     <meta charset="utf-8">
-    <title><spring:message code="tatami.title"/></title>
+    <title><fmt:message key="tatami.title"/></title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
 	<meta name="description" content=""></meta>
 	<meta name="author" content="Ippon Technologies"></meta>

--- a/src/main/webapp/WEB-INF/layouts/mobile/login.jsp
+++ b/src/main/webapp/WEB-INF/layouts/mobile/login.jsp
@@ -1,5 +1,5 @@
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 
@@ -13,14 +13,14 @@
 						<span class="icon-bar"></span>
 						<span class="icon-bar"></span>
 					</a>
-					<a class="brand" href="#"><img src="/assets/img/ippon-logo.png"></img><spring:message
-                    code="tatami.title"/></a>
+					<a class="brand" href="#"><img src="/assets/img/ippon-logo.png"></img><fmt:message
+                    key="tatami.title"/></a>
 					<div class="nav-collapse">
 						<ul class="nav">
-							<li class="active"><a href="/tatami/login"><i class="icon-lock icon-white"></i>&nbsp;<spring:message
-                            code="tatami.login"/></a></li>
-							<li><a href="/tatami/about"><i class="icon-info-sign icon-white"></i>&nbsp;<spring:message
-                            code="tatami.about"/></a></li>
+							<li class="active"><a href="/tatami/login"><i class="icon-lock icon-white"></i>&nbsp;<fmt:message
+                            key="tatami.login"/></a></li>
+							<li><a href="/tatami/about"><i class="icon-info-sign icon-white"></i>&nbsp;<fmt:message
+                            key="tatami.about"/></a></li>
 						</ul>
 					</div>
 				</div>
@@ -28,23 +28,23 @@
 		</div>
 	<br/>
     <div id="mobileLoginContainer">
-        <h1><spring:message code="tatami.authentification"/></h1>
+        <h1><fmt:message key="tatami.authentification"/></h1>
 		<br/>
         <form id="loginForm" action="/tatami/authentication" method="post" class="well" >
         	<br/>
             <fieldset>
-                <label><spring:message code="tatami.login"/> :</label> <input id="j_username" name="j_username"
+                <label><fmt:message key="tatami.login"/> :</label> <input id="j_username" name="j_username"
                        type="text" required="required" autofocus="autofocus" class="input-large"
-                       placeholder="<spring:message code="tatami.login"/>..."/>
-                <label><spring:message code="tatami.password"/> :</label> <input id="j_password" name="j_password"
+                       placeholder="<fmt:message key="tatami.login"/>..."/>
+                <label><fmt:message key="tatami.password"/> :</label> <input id="j_password" name="j_password"
                        type="password" required="required" class="input-large"
-                       placeholder="<spring:message code="tatami.password"/>..."/>
-	            <label class="checkbox"><spring:message code="tatami.remember.password.time"/> :</label> <input type="checkbox"
+                       placeholder="<fmt:message key="tatami.password"/>..."/>
+	            <label class="checkbox"><fmt:message key="tatami.remember.password.time"/> :</label> <input type="checkbox"
 	                       name="_spring_security_remember_me" id="_spring_security_remember_me"
 	                       value="true" checked="true"/>
             </fieldset>
 
-            <button type="submit" class="btn btn-success btn-large"><spring:message code="tatami.authentificate"/></button>
+            <button type="submit" class="btn btn-success btn-large"><fmt:message key="tatami.authentificate"/></button>
             <br/>&nbsp;
         </form>
     </div>

--- a/src/main/webapp/WEB-INF/layouts/standard/404-error.jsp
+++ b/src/main/webapp/WEB-INF/layouts/standard/404-error.jsp
@@ -1,6 +1,6 @@
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 <!DOCTYPE html>
 <html lang="en">
@@ -17,7 +17,7 @@
         <div class="span8">
             <table>
                 <tr>
-                    <td><h1><spring:message code="tatami.404"/></h1></td>
+                    <td><h1><fmt:message key="tatami.404"/></h1></td>
                     <td><img src="/assets/img/404-error.jpg" width="500" height="570"/></td>
                 </tr>
             </table>

--- a/src/main/webapp/WEB-INF/layouts/standard/500-error.jsp
+++ b/src/main/webapp/WEB-INF/layouts/standard/500-error.jsp
@@ -1,6 +1,6 @@
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 <!DOCTYPE html>
 <html lang="en">
@@ -17,7 +17,7 @@
         <div class="span8">
             <table>
                 <tr>
-                    <td><h1><spring:message code="tatami.500"/></h1></td>
+                    <td><h1><fmt:message key="tatami.500"/></h1></td>
                     <td><img src="/assets/img/500-error.jpg" width="500" height="478"/></td>
                 </tr>
             </table>

--- a/src/main/webapp/WEB-INF/layouts/standard/about.jsp
+++ b/src/main/webapp/WEB-INF/layouts/standard/about.jsp
@@ -1,5 +1,5 @@
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 <!DOCTYPE html>
 <html lang="en">
@@ -12,25 +12,25 @@
 
 <div class="container-fluid mainPanel">
     <div class="span8">
-        <h1><spring:message code="tatami.presentation"/></h1>
+        <h1><fmt:message key="tatami.presentation"/></h1>
 
-        <p><spring:message code="tatami.presentation.text"/></p>
+        <p><fmt:message key="tatami.presentation.text"/></p>
 
         <p>
-            <spring:message code="tatami.presentation.moreinfo"/><a href="https://github.com/ippontech/tatami">https://github.com/ippontech/tatami</a>
+            <fmt:message key="tatami.presentation.moreinfo"/><a href="https://github.com/ippontech/tatami">https://github.com/ippontech/tatami</a>
         </p>
 
-        <h1><spring:message code="tatami.license"/></h1>
+        <h1><fmt:message key="tatami.license"/></h1>
 
-        <p><spring:message code="tatami.copyright"/> <a href="http://www.ippon.fr"><spring:message
-                code="tatami.ippon.technologies"/></a></p>
+        <p><fmt:message key="tatami.copyright"/> <a href="http://www.ippon.fr"><fmt:message
+                key="tatami.ippon.technologies"/></a></p>
 
-        <p><spring:message code="tatami.license.text"/></p>
+        <p><fmt:message key="tatami.license.text"/></p>
 
         <p><a href="http://www.apache.org/licenses/LICENSE-2.0"></a><a
                 href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a></p>
 
-        <p><spring:message code="tatami.cg"/></p>
+        <p><fmt:message key="tatami.cg"/></p>
     </div>
 </div>
 <br/><br/><br/><br/><br/><br/>

--- a/src/main/webapp/WEB-INF/layouts/standard/home.jsp
+++ b/src/main/webapp/WEB-INF/layouts/standard/home.jsp
@@ -1,5 +1,5 @@
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 <!DOCTYPE html>
 <html lang="en">
@@ -15,10 +15,10 @@
         <div id="menuContent" class="span4">
             <ul class="nav nav-tabs">
                 <li class="active"><a id="profileTab" href="#profileTabContent" data-toggle="pill">
-                    &nbsp;<spring:message code="tatami.show.profile"/></a></li>
+                    &nbsp;<fmt:message key="tatami.show.profile"/></a></li>
                 <li><a id="updateProfileTab" href="#updateProfileTabContent" data-toggle="pill"><i
                         class="icon-edit"></i>&nbsp;
-                    <spring:message code="tatami.update.profile"/></a></li>
+                    <fmt:message key="tatami.update.profile"/></a></li>
             </ul>
             <div class="alert alert-info">
                 <div class="tab-content" style="margin-left: -10px;">
@@ -32,16 +32,16 @@
                             </div>
                             <div id="badges" class="well well-small row-fluid">
                                 <div class="span4">
-                                    <span id="tweetCount" class="badge"></span><br/><spring:message
-                                        code="tatami.badge.tweets"/>
+                                    <span id="tweetCount" class="badge"></span><br/><fmt:message
+                                        key="tatami.badge.tweets"/>
                                 </div>
                                 <div class="span4">
-                                    <span id="friendsCount" class="badge"></span><br/><spring:message
-                                        code="tatami.badge.followed"/>
+                                    <span id="friendsCount" class="badge"></span><br/><fmt:message
+                                        key="tatami.badge.followed"/>
                                 </div>
                                 <div class="span4">
-                                    <span id="followersCount" class="badge"></span><br/><spring:message
-                                        code="tatami.badge.followers"/>
+                                    <span id="followersCount" class="badge"></span><br/><fmt:message
+                                        key="tatami.badge.followers"/>
                                 </div>
                             </div>
                             <div class="row-fluid">
@@ -62,11 +62,11 @@
                                 <form id="updateUserForm" onsubmit="return updateProfile();">
                                     <fieldset>
                                         <img id="pictureInput"/>
-                                        <label><spring:message
-                                                code="tatami.user.picture"/> <a href="http://www.gravatar.com" target="_blank">http://www.gravatar.com</a>
+                                        <label><fmt:message
+                                                key="tatami.user.picture"/> <a href="http://www.gravatar.com" target="_blank">http://www.gravatar.com</a>
                                         </label>
-                                        <label><spring:message
-                                                code="tatami.user.email"/> :</label>
+                                        <label><fmt:message
+                                                key="tatami.user.email"/> :</label>
                                         <input id="emailInput"
                                                name="email"
                                                type="email"
@@ -75,16 +75,16 @@
                                                maxlength="60"
                                                placeholder="Enter e-mail..."/>
 
-                                        <label><spring:message
-                                                code="tatami.user.firstName"/> :</label>
+                                        <label><fmt:message
+                                                key="tatami.user.firstName"/> :</label>
                                         <input
                                                 id="firstNameInput" name="firstName"
                                                 type="text"
                                                 required="required"
                                                 size="15" maxlength="40"
                                                 placeholder="Enter first name..."/>
-                                        <label><spring:message
-                                                code="tatami.user.lastName"/> :</label>
+                                        <label><fmt:message
+                                                key="tatami.user.lastName"/> :</label>
                                         <input id="lastNameInput"
                                                name="lastName"
                                                type="text"
@@ -111,22 +111,22 @@
             <div class="tabbable">
                 <ul class="nav nav-tabs">
                     <li class="active"><a id="mainTab" href="#timeLinePanel" data-toggle="tab"><i
-                            class="icon-th-list"></i>&nbsp;<spring:message code="tatami.tweets"/></a></li>
+                            class="icon-th-list"></i>&nbsp;<fmt:message key="tatami.tweets"/></a></li>
                     <li><a id="favTab" href="#favLinePanel" data-toggle="tab"><i
-                            class="icon-star"></i>&nbsp;<spring:message code="tatami.user.favoritetweets"/></a></li>
+                            class="icon-star"></i>&nbsp;<fmt:message key="tatami.user.favoritetweets"/></a></li>
                     <li><a id="tagTab" href="#tagLinePanel" data-toggle="tab"><i
-                            class="icon-tag"></i>&nbsp;<spring:message code="tatami.tags"/></a></li>
+                            class="icon-tag"></i>&nbsp;<fmt:message key="tatami.tags"/></a></li>
                     <li><a id="searchTab" href="#searchLinePanel" data-toggle="tab"><i
-                            class="icon-search"></i>&nbsp;<spring:message code="tatami.search"/></a></li>
+                            class="icon-search"></i>&nbsp;<fmt:message key="tatami.search"/></a></li>
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i
-                                class="icon-signal"></i>&nbsp;<spring:message code="tatami.tweets.stats"/>&nbsp;<b
+                                class="icon-signal"></i>&nbsp;<fmt:message key="tatami.tweets.stats"/>&nbsp;<b
                                 class="caret"></b></a>
                         <ul class="dropdown-menu">
-                            <li><a id="piechartTab" href="#piechartPanel" data-toggle="tab"><spring:message
-                                    code="tatami.stats.tweets.piechart"/></a></li>
-                            <li><a id="punchchartTab" href="#punchchartPanel" data-toggle="tab"><spring:message
-                                    code="tatami.stats.tweets.punchchart"/></a></li>
+                            <li><a id="piechartTab" href="#piechartPanel" data-toggle="tab"><fmt:message
+                                    key="tatami.stats.tweets.piechart"/></a></li>
+                            <li><a id="punchchartTab" href="#punchchartPanel" data-toggle="tab"><fmt:message
+                                    key="tatami.stats.tweets.punchchart"/></a></li>
                         </ul>
                     </li>
                 </ul>
@@ -164,11 +164,6 @@
 <jsp:include page="includes/footer.jsp"/>
 
 <script type="text/javascript" src="https://www.google.com/jsapi"></script>
-<spring:eval expression="@applicationProps['tatami.version']" var="applicationVersion"/>
-
-<spring:url value="resources/{applicationVersion}" var="resourceUrl">
-    <spring:param name="applicationVersion" value="${applicationVersion}"/>
-</spring:url>
 
 <script src="/assets/js/tatami/standard/tatami.js"></script>
 <script src="/assets/js/tatami/standard/tatami.charts.js"></script>

--- a/src/main/webapp/WEB-INF/layouts/standard/includes/footer.jsp
+++ b/src/main/webapp/WEB-INF/layouts/standard/includes/footer.jsp
@@ -1,11 +1,11 @@
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 <footer>
     <div id="footer" class="navbar navbar-fixed-bottom">
-        <a href="http://www.ippon.fr" id="footer_ippon"><spring:message code="tatami.copyright"/> <spring:message code="tatami.ippon.technologies"/></a> |
-        <a href="https://github.com/ippontech/tatami" id="footer_github"><spring:message code="tatami.github.fork"/></a> |
-        <a href="http://blog.ippon.fr" id="footer_blog"><spring:message code="tatami.ippon.blog"/></a> |
-        <a href="https://twitter.com/#!/ippontech" id="footer_twitter"><spring:message code="tatami.ippon.twitter.follow"/></a>
+        <a href="http://www.ippon.fr" id="footer_ippon"><fmt:message key="tatami.copyright"/> <fmt:message key="tatami.ippon.technologies"/></a> |
+        <a href="https://github.com/ippontech/tatami" id="footer_github"><fmt:message key="tatami.github.fork"/></a> |
+        <a href="http://blog.ippon.fr" id="footer_blog"><fmt:message key="tatami.ippon.blog"/></a> |
+        <a href="https://twitter.com/#!/ippontech" id="footer_twitter"><fmt:message key="tatami.ippon.twitter.follow"/></a>
     </div>
 </footer>
 

--- a/src/main/webapp/WEB-INF/layouts/standard/includes/header.jsp
+++ b/src/main/webapp/WEB-INF/layouts/standard/includes/header.jsp
@@ -1,8 +1,9 @@
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+
 
 <head>
     <meta charset="utf-8">
-    <title><spring:message code="tatami.title"/></title>
+    <title><fmt:message key="tatami.title"/></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="Ippon Technologies">

--- a/src/main/webapp/WEB-INF/layouts/standard/includes/topmenu.jsp
+++ b/src/main/webapp/WEB-INF/layouts/standard/includes/topmenu.jsp
@@ -1,5 +1,5 @@
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 <div class="navbar navbar-fixed-top">
     <div class="navbar-inner">
@@ -9,21 +9,21 @@
                 <span class="icon-bar"></span>
             </a>
             <a class="brand" href="/tatami/"><img
-                    src="${request.getContextPath}/assets/img/ippon-logo.png">&nbsp;<spring:message
-                    code="tatami.title"/></a>
+                    src="${request.getContextPath}/assets/img/ippon-logo.png">&nbsp;<fmt:message
+                    key="tatami.title"/></a>
 
             <div class="nav-collapse">
                 <ul class="nav">
-                    <li class="active"><a href="/tatami/"><i class="icon-home icon-white"></i>&nbsp;<spring:message
-                            code="tatami.home"/></a></li>
-                    <li><a href="/tatami/about"><i class="icon-info-sign icon-white"></i>&nbsp;<spring:message
-                            code="tatami.about"/></a></li>
+                    <li class="active"><a href="/tatami/"><i class="icon-home icon-white"></i>&nbsp;<fmt:message
+                            key="tatami.home"/></a></li>
+                    <li><a href="/tatami/about"><i class="icon-info-sign icon-white"></i>&nbsp;<fmt:message
+                            key="tatami.about"/></a></li>
                 </ul>
                 <sec:authorize access="hasRole('ROLE_USER')" >
                     <ul class="nav pull-right">
                         <li class="divider-vertical"></li>
-                        <li><a href="/tatami/logout"><i class="icon-user icon-white"></i>&nbsp;<spring:message
-                                code="tatami.logout"/></a></li>
+                        <li><a href="/tatami/logout"><i class="icon-user icon-white"></i>&nbsp;<fmt:message
+                                key="tatami.logout"/></a></li>
                     </ul>
                     <ul class="nav pull-right">
                         <form id="global-tweet-search" class="well form-search" action="/tatami/rest/search"
@@ -31,9 +31,9 @@
                             <input type="hidden" name="page" value="0"/>
                             <input type="hidden" name="rpp" value="20"/>
                             <input type="text" id="searchQuery" name="q" class="input-medium search-query"
-                                   placeholder="<spring:message code="tatami.search.placeholder"/>">
-                            <button type="submit" class="btn" style="margin-top:0px;"><spring:message
-                                    code="tatami.search.button"/></button>
+                                   placeholder="<fmt:message key="tatami.search.placeholder"/>">
+                            <button type="submit" class="btn" style="margin-top:0px;"><fmt:message
+                                    key="tatami.search.button"/></button>
                         </form>
                     </ul>
                 </sec:authorize>

--- a/src/main/webapp/WEB-INF/layouts/standard/login.jsp
+++ b/src/main/webapp/WEB-INF/layouts/standard/login.jsp
@@ -1,5 +1,5 @@
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 <!DOCTYPE html>
 <html lang="en">
@@ -12,15 +12,15 @@
 
 <div class="container">
     <div class="span4 offset4">
-        <h1><spring:message code="tatami.authentification"/></h1>
+        <h1><fmt:message key="tatami.authentification"/></h1>
 
         <form action="/tatami/authentication" method="post" class="well">
             <fieldset>
-                <label><spring:message code="tatami.login"/>&nbsp;:</label> <input id="j_username" name="j_username"
+                <label><fmt:message key="tatami.login"/>&nbsp;:</label> <input id="j_username" name="j_username"
                                                                                    type="text" required="required"
                                                                                    autofocus class="input-xlarge"
                                                                                    placeholder="Your login..."/>
-                <label><spring:message code="tatami.password"/>&nbsp;:</label> <input id="j_password" name="j_password"
+                <label><fmt:message key="tatami.password"/>&nbsp;:</label> <input id="j_password" name="j_password"
                                                                                       type="password"
                                                                                       required="required"
                                                                                       class="input-xlarge"
@@ -29,10 +29,10 @@
             <label class="checkbox">
                 <input type='checkbox'
                        name='_spring_security_remember_me' id="_spring_security_remember_me"
-                       value="true" checked="true"/>&nbsp;<spring:message code="tatami.remember.password.time"/>
+                       value="true" checked="true"/>&nbsp;<fmt:message key="tatami.remember.password.time"/>
             </label>
 
-            <button type="submit" class="btn btn-success"><spring:message code="tatami.authentificate"/></button>
+            <button type="submit" class="btn btn-success"><fmt:message key="tatami.authentificate"/></button>
         </form>
     </div>
 </div>

--- a/src/main/webapp/WEB-INF/layouts/standard/profile.jsp
+++ b/src/main/webapp/WEB-INF/layouts/standard/profile.jsp
@@ -1,6 +1,5 @@
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 <!DOCTYPE html>
@@ -29,50 +28,50 @@
                     <c:choose>
                         <c:when test="${not empty user && user.login eq login}">
                             <div class="btn btn-info"
-                                 title="It s you"><spring:message code="tatami.user.yourself"/>
+                                 title="It s you"><fmt:message key="tatami.user.yourself"/>
                             </div>
                         </c:when>
                         <c:when test="${not empty followed && followed}">
                             <a href="#" id="unfollowBtn"
                                onclick="unfollowUserProfile(userLogin)"
                                class="btn btn-info"
-                               title="${user.firstName}&nbsp;${user.lastName}"><spring:message
-                                    code="tatami.user.followed"/></a>
+                               title="${user.firstName}&nbsp;${user.lastName}"><fmt:message
+                                    key="tatami.user.followed"/></a>
                             <a href="#" id="followBtn"
                                onclick="followUserProfile(userLogin)"
                                class="btn btn-info hide"
-                               title="${user.firstName}&nbsp;${user.lastName}"><spring:message
-                                    code="tatami.user.follow"/></a>
+                               title="${user.firstName}&nbsp;${user.lastName}"><fmt:message
+                                    key="tatami.user.follow"/></a>
                         </c:when>
                         <c:otherwise>
                             <a href="#" id="unfollowBtn"
                                onclick="unfollowUserProfile(userLogin)"
                                class="btn btn-info hide"
-                               title="${user.firstName}&nbsp;${user.lastName}"><spring:message
-                                    code="tatami.user.followed"/></a>
+                               title="${user.firstName}&nbsp;${user.lastName}"><fmt:message
+                                    key="tatami.user.followed"/></a>
                             <a href="#" id="followBtn"
                                onclick="followUserProfile(userLogin)"
                                class="btn btn-info"
-                               title="${user.firstName}&nbsp;${user.lastName}"><spring:message
-                                    code="tatami.user.follow"/></a>
+                               title="${user.firstName}&nbsp;${user.lastName}"><fmt:message
+                                    key="tatami.user.follow"/></a>
                         </c:otherwise>
                     </c:choose>
                 </div>
 
                 <div class="span1" style="width: 70px">
                     <span class="badge"><fmt:formatNumber value="${nbTweets}"
-                                                          pattern="# ### ###"/></span><br/><spring:message
-                        code="tatami.badge.tweets"/>
+                                                          pattern="# ### ###"/></span><br/><fmt:message
+                        key="tatami.badge.tweets"/>
                 </div>
                 <div class="span1" style="width: 70px">
                     <span class="badge"><fmt:formatNumber value="${nbFollowed}"
-                                                          pattern="# ### ###"/></span><br/><spring:message
-                        code="tatami.badge.followed"/>
+                                                          pattern="# ### ###"/></span><br/><fmt:message
+                        key="tatami.badge.followed"/>
                 </div>
                 <div class="span1" style="width: 70px">
                     <span class="badge"><fmt:formatNumber value="${nbFollowers}"
-                                                          pattern="# ### ###"/></span><br/><spring:message
-                        code="tatami.badge.followers"/>
+                                                          pattern="# ### ###"/></span><br/><fmt:message
+                        key="tatami.badge.followers"/>
                 </div>
             </div>
 
@@ -81,24 +80,24 @@
                     <div class="alert alert-info">
                         <ul class="nav nav-pills nav-stacked">
                             <li class="active">
-                                <a id="tweetsTab" href="#tweetsPanel" data-toggle="tab"><spring:message
-                                        code="tatami.badge.tweets"/></a>
+                                <a id="tweetsTab" href="#tweetsPanel" data-toggle="tab"><fmt:message
+                                        key="tatami.badge.tweets"/></a>
                             </li>
-                            <li><a id="followingTab" href="#followingPanel" data-toggle="tab"><spring:message
-                                    code="tatami.badge.followed"/></a></li>
-                            <li><a id="followersTab" href="#followersPanel" data-toggle="tab"><spring:message
-                                    code="tatami.badge.followers"/></a></li>
+                            <li><a id="followingTab" href="#followingPanel" data-toggle="tab"><fmt:message
+                                    key="tatami.badge.followed"/></a></li>
+                            <li><a id="followersTab" href="#followersPanel" data-toggle="tab"><fmt:message
+                                    key="tatami.badge.followers"/></a></li>
                         </ul>
                     </div>
                     <div class="alert alert-info">
-                        <h4><spring:message code="tatami.user.tweettohim"/>@${user.login}</h4><br/>
+                        <h4><fmt:message key="tatami.user.tweettohim"/>@${user.login}</h4><br/>
 
                         <div id="tweetToHim" class="row-fluid">
                             <form class="form-inline" onsubmit="return tweetToUser();">
                                 <textarea id="tweetContent" rel="popover" class="focused"
                                           maxlength="140">@${user.login} </textarea>
-                                <button type="submit" class="btn btn-primary"><spring:message
-                                        code="tatami.user.tweet"/></button>
+                                <button type="submit" class="btn btn-primary"><fmt:message
+                                        key="tatami.user.tweet"/></button>
                             </form>
                             <div class="error"></div>
                         </div>
@@ -111,8 +110,8 @@
                             <table class="table table-striped">
                                 <thead>
                                 <tr>
-                                    <th><h2><spring:message
-                                            code="tatami.badge.followed"/></h2></th>
+                                    <th><h2><fmt:message
+                                            key="tatami.badge.followed"/></h2></th>
                                 </tr>
                                 </thead>
                                 <tbody id="followingList" class="tweetsList"></tbody>
@@ -122,7 +121,7 @@
                             <table class="table table-striped">
                                 <thead>
                                 <tr>
-                                    <th><h2><spring:message code="tatami.badge.followers"/></h2>
+                                    <th><h2><fmt:message key="tatami.badge.followers"/></h2>
                                     </th>
                                 </tr>
                                 </thead>
@@ -138,7 +137,7 @@
         <c:otherwise>
 
             <div class="row-fluid">
-                <spring:message code="tatami.user.undefined"/>
+                <fmt:message key="tatami.user.undefined"/>
             </div>
 
         </c:otherwise>


### PR DESCRIPTION
Vu que la taglib spring n'est utilisée que pour afficher des libellés, autant utiliser le tag fmt:message standard à la place.
Mais peut être que l'utilisation de spring:message avait une fonction que je n'ai pas compris ?

Testé avec une locale fr/us/de sans effets de bord apparent.
