### PR TITLE
Fix responsive design for 320*480

### DIFF
--- a/src/main/webapp/css/tatami.css
+++ b/src/main/webapp/css/tatami.css
@@ -189,6 +189,13 @@ form {
 
 /* Landscape phones and down */
 @media (max-width: 480px) {
+  .hero-unit {
+    padding: 10px;
+  }
+
+  .hero-unit h1 {
+    font-size: 42px;
+  }
 }
  
 /* Landscape phone to portrait tablet */


### PR DESCRIPTION
La classe [.hero-unit](https://github.com/ippontech/tatami/blob/master/src/main/webapp/WEB-INF/pages/login.jsp#L42-47) était trop grande pour les résolutions 320*480 et faisait apparaître une barre de scroll horizontale.
