### PR TITLE
Status messages : do not break in the middle of a word inside code blocks. (for Firefox)

### DIFF
--- a/src/main/webapp/css/tatami.css
+++ b/src/main/webapp/css/tatami.css
@@ -183,6 +183,7 @@ form {
 }
 
 .status-content pre {
+  word-break: normal;
   word-break: break-word;
 }
 


### PR DESCRIPTION
Status messages : do not break in the middle of a word inside code blocks. (for Firefox)
