### PR TITLE
Chrome notifications

### DIFF
--- a/src/main/webapp/js/tatami-commons.js
+++ b/src/main/webapp/js/tatami-commons.js
@@ -715,8 +715,36 @@ Suggester.getCaretPos = function(element) {
 	return (caretPos);
 };
 
-
-
+/**
+ * Webkit notifications manager
+ */
+function NotificationManager() {
+	var n;
+};
+NotificationManager.setNotification = function(title, msg, reload) {
+	if (title == null || msg == null) {return 0;}
+	if (!window.webkitNotifications) {return 0;}
+	if (window.webkitNotifications.checkPermission() != 0) {
+		setAllowNotification();
+		return 0;
+	}
+	if (NotificationManager.n != null) {NotificationManager.n.cancel();}
+	NotificationManager.n = window.webkitNotifications.createNotification('/favicon.ico', title, msg);
+	NotificationManager.n.onclick = function(x) {
+		window.focus();
+		if (reload) {window.location.reload();}
+		this.cancel();
+	};
+	NotificationManager.n.show();
+};
+NotificationManager.setAllowNotification = function(callback) {
+	if (!window.webkitNotifications) {return 0;}
+	if (callback != null) {
+		window.webkitNotifications.requestPermission(callback);
+	} else {
+		window.webkitNotifications.requestPermission();
+	}
+};
 
 // Fix Bootstrap navbar dropdown
 $(function (){

--- a/src/main/webapp/js/tatami-home.js
+++ b/src/main/webapp/js/tatami-home.js
@@ -367,7 +367,9 @@ app.View.TimeLineNewView = Backbone.View.extend({
           $(location).attr('href', '/tatami/login?timeout');
         }
         if (sc.length > 0) {
-          document.title = "Tatami (" + (self.temp.length + sc.length) + ")";
+       	  var nb = self.temp.length + sc.length;
+          document.title = "Tatami (" + (nb) + ")";
+          NotificationManager.setNotification("Tatami notification", (nb) + " unread statuses", true);
         } else if (sc.length == 0) {
           document.title = "Tatami";
         }
@@ -394,6 +396,7 @@ app.View.TimeLineNewView = Backbone.View.extend({
   },
 
   newStatus: function() {
+    NotificationManager.setAllowNotification();
     this.progress();
     var self = this;
     if (this.model.models.length === 0) {


### PR DESCRIPTION
First implementation

Notifications display how many unread messages were received since the last Tatami use.
When clicking on the notification, the browser gets the focus on the right tab, and the page is reloaded, showing all the statuses.

NOTE: to enable notification, each user has to click on the "Refresh" button. Only an action triggered by a user (such a click) can enable notifications: they can't be enabled automatically.
