### PR TITLE
NullPointerException corrigée

### DIFF
--- a/src/main/java/fr/ippon/tatami/service/StatusUpdateService.java
+++ b/src/main/java/fr/ippon/tatami/service/StatusUpdateService.java
@@ -294,7 +294,7 @@ public class StatusUpdateService {
         timelineRepository.addStatusToTimeline(mentionedLogin, status);
         User mentionnedUser = userRepository.findUserByLogin(mentionedLogin);
 
-        if (mentionnedUser.getPreferencesMentionEmail() == null || mentionnedUser.getPreferencesMentionEmail().equals(true)) {
+        if (mentionnedUser != null && (mentionnedUser.getPreferencesMentionEmail() == null || mentionnedUser.getPreferencesMentionEmail().equals(true))) {
             if (status.getStatusPrivate() == true) { // Private status
                 mailService.sendUserPrivateMessageEmail(status, mentionnedUser);
             } else {


### PR DESCRIPTION
Lorsqu'on mettait dans un status un @user qui n'existe pas, une NPE était levée lors du mentionUser (qui envoie un mail à l'user concerné)
