### PR TITLE
Détection des tags dans les URL

### DIFF
--- a/src/main/java/fr/ippon/tatami/service/StatusUpdateService.java
+++ b/src/main/java/fr/ippon/tatami/service/StatusUpdateService.java
@@ -25,7 +25,7 @@ public class StatusUpdateService {
 
     private final static Pattern PATTERN_LOGIN = Pattern.compile("@[^\\s]+");
 
-    private static final Pattern PATTERN_HASHTAG = Pattern.compile("#([^\\s !\"#$%&\'()*+,./:;<=>?@\\\\\\[\\]^_`{|}~-]+)");
+    private static final Pattern PATTERN_HASHTAG = Pattern.compile("(^|\\s)#([^\\s !\"#$%&\'()*+,./:;<=>?@\\\\\\[\\]^_`{|}~-]+)");
 
     @Inject
     private FollowerRepository followerRepository;
@@ -224,7 +224,7 @@ public class StatusUpdateService {
     private void manageStatusTags(Status status, Group group) {
         Matcher m = PATTERN_HASHTAG.matcher(status.getContent());
         while (m.find()) {
-            String tag = m.group(1);
+            String tag = m.group(2);
             if (tag != null && !tag.isEmpty() && !tag.contains("#")) {
                 if (log.isDebugEnabled()) {
                     log.debug("Found tag : " + tag);


### PR DESCRIPTION
Avant les tags dans les url étaient détectés, par ex tester http://www.google.fr/#coincoin cela ajoute le tag #coincoin ; avec la correction un tag doit être en début de ligne ou précédé d'un caractère vide pour être considéré comme vrai tag.
