### PR TITLE
Use googleClosure for js minimization instead of jsMin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
                             <destinationFolder>${basedir}/src/main/webapp/WEB-INF/generated-wro4j</destinationFolder>
                             <contextFolder>${basedir}/src/main/webapp</contextFolder>
                             <ignoreMissingResources>false</ignoreMissingResources>
+                            <wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
                         </configuration>
                         <dependencies>
                             <dependency>

--- a/src/main/webapp/WEB-INF/wro.properties
+++ b/src/main/webapp/WEB-INF/wro.properties
@@ -1,0 +1,1 @@
+preProcessors=cssUrlRewriting, cssImport, cssMinJawr, semicolonAppender, googleClosureSimple


### PR DESCRIPTION
@jdubois: here is a pull request which fix the problem with js minimization. The pull request has a small change which replace the jsMin minimizer with googleClosure. The later is better and more efficient. 

Apparently the cause of the problem was the following statement from underscore.js:

```
var id = '' + ++idCounter;
```

When minimized with jsMin, it produces the following js:

```
var id=''+++idCounter;
```

which is obviously is an invalid statement. 
