### PR TITLE
Fix bug on public group

### DIFF
--- a/src/main/java/fr/ippon/tatami/repository/cassandra/CassandraGroupDetailsRepository.java
+++ b/src/main/java/fr/ippon/tatami/repository/cassandra/CassandraGroupDetailsRepository.java
@@ -68,7 +68,7 @@ public class CassandraGroupDetailsRepository implements GroupDetailsRepository {
                 StringSerializer.get(), StringSerializer.get(), StringSerializer.get())
                 .setColumnFamily(GROUP_DETAILS_CF)
                 .setKey(groupId)
-                .setRange(null, null, false, 3)
+                .setRange(null, null, false, 4)
                 .execute()
                 .get();
 


### PR DESCRIPTION
- publics group were always read from cassandra as private groups
  because the publicGroup column was never read (but correclty written)
