### PR TITLE
Fix js error on preferences

### DIFF
--- a/src/main/webapp/js/tatami-admin.js
+++ b/src/main/webapp/js/tatami-admin.js
@@ -149,6 +149,7 @@ app.View.Preferences = Backbone.View.extend({
 
     render: function(){
         this.$el.empty();
+        this.model.attributes.themesList = (this.model.attributes.themesList== undefined) ? [] : this.model.attributes.themesList;
         this.$el.html(this.template({
             preferences: this.model.toJSON()
         }));


### PR DESCRIPTION
- the backbone view is rendered several times (on addView to the Router
  and when getting the request response)
- calling render with an empty model causes this error
