### PR TITLE
Reduce quotation size in tatam.

### DIFF
--- a/src/main/webapp/css/tatami.css
+++ b/src/main/webapp/css/tatami.css
@@ -512,6 +512,10 @@ div.jGrowl-notification{
     }
 }
 
+.tatam blockquote p {
+    font-size: 0.8em;
+}
+
 .tatams-content-title {
     border-top: 1px solid #CCCCCC;
     border-left: 1px solid #CCCCCC;


### PR DESCRIPTION
Quotations in tatams are too big (bigger than the answer to this quotation). A smaller size improves tatam redability.
