### PR TITLE
Add missing jquery.placeholder.js asset in wro4j config

### DIFF
--- a/src/main/webapp/WEB-INF/wro.xml
+++ b/src/main/webapp/WEB-INF/wro.xml
@@ -3,6 +3,7 @@
 <groups xmlns="http://www.isdc.ro/wro">
     <group name='tatami-vendor'>
         <js>/js/vendor/jquery.js</js>
+        <js>/js/vendor/jquery.placeholder.js</js>
         <js>/js/vendor/jquery.ui.widget.js</js>
         <js>/js/vendor/jquery.iframe-transport.js</js>
         <js>/js/vendor/jquery.fileupload.js</js>


### PR DESCRIPTION
Without it there is a javascript error on home page leaving it blank.
