### PR TITLE
Fixed bug when killing the server while user was at home.timeline, if th...

### DIFF
--- a/src/main/webapp/app/shared/services/UserSession.js
+++ b/src/main/webapp/app/shared/services/UserSession.js
@@ -1,6 +1,7 @@
 TatamiApp.factory('UserSession', ['$q', '$window', 'ProfileService', 'localStorageService', function($q, $window, ProfileService, localStorageService) {
     var user;
     var authenticated = false;
+    localStorageService.set('token', false);
 
     return {
         isAuthenticated: function() {


### PR DESCRIPTION
...e server was restarted and the page was refreshed, the server would try to reload the timeline, rather than redirect to login state